### PR TITLE
Cluster destroy patch

### DIFF
--- a/resource_container_replica_controller.go
+++ b/resource_container_replica_controller.go
@@ -98,11 +98,23 @@ func resourceContainerReplicaControllerCreate(d *schema.ResourceData, meta inter
 	return nil
 }
 
+// if the error string has a 'code=404' in it, the owning cluster is gone.  
+//  remove the rc from the tfstate file
+func checkMissingCluster(d *schema.ResourceData, err error) error {
+	if strings.Contains(err.Error(), 'code=404') {
+		//  the owning cluster doesn't exist, the container can't
+		d.SetId("")
+		return nil
+	}
+	return err	
+}
+
+
 func resourceContainerReplicaControllerRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	err := config.initKubectl(d.Get("container_name").(string), d.Get("zone").(string))
 	if err != nil {
-		return err
+		return checkMissingCluster(d, err)
 	}
 
 	pod_count, external_ip, err := ReadKubeRC(d.Get("name").(string), d.Get("external_port").(string))
@@ -126,7 +138,7 @@ func resourceContainerReplicaControllerDelete(d *schema.ResourceData, meta inter
 	config := meta.(*Config)
 	err := config.initKubectl(d.Get("container_name").(string), d.Get("zone").(string))
 	if err != nil {
-		return err
+		return checkMissingCluster(d, err)
 	}
 
 	err = DeleteKubeRC(d.Get("name").(string),d.Get("external_port").(string)) 

--- a/resource_container_replica_controller.go
+++ b/resource_container_replica_controller.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"strings"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -101,7 +102,7 @@ func resourceContainerReplicaControllerCreate(d *schema.ResourceData, meta inter
 // if the error string has a 'code=404' in it, the owning cluster is gone.  
 //  remove the rc from the tfstate file
 func checkMissingCluster(d *schema.ResourceData, err error) error {
-	if strings.Contains(err.Error(), 'code=404') {
+	if strings.Contains(err.Error(), "code=404") {
 		//  the owning cluster doesn't exist, the container can't
 		d.SetId("")
 		return nil


### PR DESCRIPTION
if the cluster is deleted out of band but the RC is still in the
state file, TF needs to be able to dump the RC from the state file
without having to talk to anything